### PR TITLE
fix capabilities

### DIFF
--- a/statnot
+++ b/statnot
@@ -231,7 +231,7 @@ class NotificationFetcher(dbus.service.Object):
 
     @dbus.service.method("org.freedesktop.Notifications", in_signature='', out_signature='as')
     def GetCapabilities(self):
-        return ("body")
+        return (["body"])
 
     @dbus.service.signal('org.freedesktop.Notifications', signature='uu')
     def NotificationClosed(self, id_in, reason_in):


### PR DESCRIPTION
capabilities need to be returned as array, else it is interpreted as ["b","o","d","y"]

further i recommend to return even more capabilities, else some programs like eg brave will refuse to use your notification service

example which works for me and brave:

return (["actions", "body", "body-hyperlinks", "body-markup", "icon-static", "x-canonical-private-icon-only"])